### PR TITLE
[IMP] sale: Add a hook to let the other modules updating the discount

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -869,7 +869,7 @@ class SaleOrderLine(models.Model):
                 # reduce (to include discount) without using `compute_all()` method on taxes.
                 price_subtotal = 0.0
                 uom_qty_to_consider = line.qty_delivered if line.product_id.invoice_policy == 'delivery' else line.product_uom_qty
-                price_reduce = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
+                price_reduce = line.price_unit * (1 - (line._get_discount() or 0.0) / 100.0)
                 price_subtotal = price_reduce * uom_qty_to_consider
                 if len(line.tax_id.filtered(lambda tax: tax.price_include)) > 0:
                     # As included taxes are not excluded from the computed subtotal, `compute_all()` method
@@ -882,7 +882,7 @@ class SaleOrderLine(models.Model):
                         product=line.product_id,
                         partner=line.order_id.partner_shipping_id)['total_excluded']
                 inv_lines = line._get_invoice_lines()
-                if any(inv_lines.mapped(lambda l: l.discount != line.discount)):
+                if line._needs_remaining_calculation(inv_lines):
                     # In case of re-invoicing with different discount we try to calculate manually the
                     # remaining amount to invoice
                     amount = 0
@@ -897,6 +897,12 @@ class SaleOrderLine(models.Model):
                     amount_to_invoice = price_subtotal - line.untaxed_amount_invoiced
 
             line.untaxed_amount_to_invoice = amount_to_invoice
+
+    def _needs_remaining_calculation(self, inv_lines):
+        return any(inv_lines.mapped(lambda l: l.discount != self.discount))
+
+    def _get_discount(self):
+        return self.discount
 
     @api.depends('order_id.partner_id', 'product_id')
     def _compute_analytic_distribution(self):

--- a/doc/cla/individual/lethuthao2403.md
+++ b/doc/cla/individual/lethuthao2403.md
@@ -1,0 +1,11 @@
+Vietnam, 2023-12-07
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Thao Le thaorom19999@gmail.com https://github.com/lethuthao2403


### PR DESCRIPTION
**Context:** 
- In the module `sale_triple_discount`, i need to recompute the value of the field `untaxed_amount_to_invoice` when the value of any of ("discount2", "discount3", "discounting_type") changed.
- I add a new method `def _get_discount(self)` to get the discount, so `sale_triple_discount` can override it.

`sale_triple_discount`: https://github.com/OCA/sale-workflow/